### PR TITLE
fix(workflows): pass engine option through resolveModule

### DIFF
--- a/src/workflows/utils/resolvers/module.ts
+++ b/src/workflows/utils/resolvers/module.ts
@@ -42,6 +42,7 @@ export function resolveModule(id: string, overrides: ModuleOverrides = {}): Work
   const promptPath = overrides.promptPath ?? moduleEntry.promptPath;
   const model = overrides.model ?? moduleEntry.model;
   const modelReasoningEffort = overrides.modelReasoningEffort ?? moduleEntry.modelReasoningEffort;
+  const engine = overrides.engine ?? moduleEntry.engine;
 
   if (typeof promptPath !== 'string' || !promptPath.trim()) {
     throw new Error(`Module ${id} is missing a promptPath configuration.`);
@@ -56,6 +57,7 @@ export function resolveModule(id: string, overrides: ModuleOverrides = {}): Work
     promptPath,
     model,
     modelReasoningEffort,
+    engine,
     module: {
       id: moduleEntry.id,
       behavior,


### PR DESCRIPTION
  resolveModule was not passing the engine option from workflow overrides
  or module config, causing workflows to fall back to default engine
  instead of using the specified one.

  This aligns resolveModule with resolveStep which already handles engine
  correctly.

Should resolve https://github.com/moazbuilds/CodeMachine-CLI/issues/37
