### PR TITLE
fix(init): correct branch name typo codemacine -> codemachine

### DIFF
--- a/prompts/templates/dev-codemachine/main-agents/00-init.md
+++ b/prompts/templates/dev-codemachine/main-agents/00-init.md
@@ -2,10 +2,10 @@
 
 **Task:**
 
-1.  **Ensure the current branch is `codemacine/dev` by following this specific logic:**
-    * First, check if the *current* branch is already `codemacine/dev`. If it is, this step is complete.
-    * If not, check if a branch named `codemacine/dev` *already exists*. If it does, switch to it.
-    * If it does not exist, create it as a new branch and switch to it (e.g., `git checkout -b codemacine/dev`).
+1.  **Ensure the current branch is `codemachine/dev` by following this specific logic:**
+    * First, check if the *current* branch is already `codemachine/dev`. If it is, this step is complete.
+    * If not, check if a branch named `codemachine/dev` *already exists*. If it does, switch to it.
+    * If it does not exist, create it as a new branch and switch to it (e.g., `git checkout -b codemachine/dev`).
 
 2.  **Append the following lines to the `.gitignore` file, skipping any that already exist:**
     ```


### PR DESCRIPTION
## Summary
- Fixed typo in `prompts/templates/dev-codemachine/main-agents/00-init.md` where branch name was misspelled as `codemacine/dev` instead of `codemachine/dev`

Fixes #43

## Test plan
- [x] Run the init agent and verify it creates a branch named `codemachine/dev` (not `codemacine/dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)