### PR TITLE
feat(auth): add support for interactive OpenCode provider additions when authenticated

### DIFF
--- a/src/infra/engines/providers/opencode/auth.ts
+++ b/src/infra/engines/providers/opencode/auth.ts
@@ -7,7 +7,6 @@ import {
   displayCliNotInstalledError,
   isCommandNotFoundError,
   ensureAuthDirectory,
-  createCredentialFile,
 } from '../../core/auth.js';
 import { metadata } from './metadata.js';
 import { ENV } from './config.js';


### PR DESCRIPTION
- Implemented `handleOpenCodeAddProvider` for managing multiple OpenCode providers interactively.
- Added special handling for authenticated OpenCode scenarios in `use-home-commands`.
- Removed unused `createCredentialFile` import from OpenCode auth module.